### PR TITLE
Fixes Issue #8, As requested, changing the x-integration: si-mcp whil…

### DIFF
--- a/src/si_mcp_server_oss/utils.py
+++ b/src/si_mcp_server_oss/utils.py
@@ -83,7 +83,7 @@ async def fetch_token(
         logger.info(f"Creating new token for tenant {si_tenant_id}")
         token = None
         url = f"{SI_BASE_URL}/tenants/{si_tenant_id}/token"
-        headers = {"x-api-key": f"{si_api_key}", "Content-Type": "application/json"}
+        headers = {"x-api-key": f"{si_api_key}", "Content-Type": "application/json", "x-integration": "si-mcp", "x-integration-version": "v1"}
         async with httpx.AsyncClient() as client:
             try:
                 response = await client.post(url, headers=headers, timeout=30.0)
@@ -140,7 +140,7 @@ async def call_ibm_storageinsights_api(
     logger.info(f"Fetch the token for SI API invocation for tenant id {tenant_id}")
     token = await fetch_token(tenant_id, api_key, logger)
 
-    headers = {"x-api-token": f"{token}", "Content-Type": "application/json"}
+    headers = {"x-api-token": f"{token}", "Content-Type": "application/json", "x-integration": "si-mcp", "x-integration-version": "v1"}
     async with httpx.AsyncClient() as client:
         try:
             response = await client.get(


### PR DESCRIPTION
…e making external api calls

# Changes:
1. Inside utils.py:
- As Requested , changing the "x-integration": "storage-insights-mcp" value to "x-integration": "si-mcp". 

# Unit Test:
- Verified the change locally to ensure the new header value is correctly applied in outgoing REST API requests.
<img width="1702" height="719" alt="Screenshot 2025-08-26 at 4 06 13 PM" src="https://github.com/user-attachments/assets/0aeab4f6-d884-4c50-8f39-017c4b6636c4" />

